### PR TITLE
Fix the EventInterface::stopPropagation() method

### DIFF
--- a/proposed/event-manager.md
+++ b/proposed/event-manager.md
@@ -118,7 +118,7 @@ interface EventInterface
      *
      * @param  bool $flag
      */
-    public function stopPropagation();
+    public function stopPropagation($flag);
 
     /**
      * Has this event indicated event propagation should stop?


### PR DESCRIPTION
The phpDoc of the `EventInterface::stopPropagation()` method defines a boolean parameter, however the method has no arguments. This PR adds the missing `$flag` argument.